### PR TITLE
feat: upgrade fink v0.53.2 + cross-module go-to-definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ node_modules/
 
 /.claude/settings.local.json
 /.claude.local/
+
+/.brain/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,11 +29,11 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "fink"
 version = "0.0.0"
-source = "git+https://github.com/fink-lang/fink.git?tag=v0.36.0#b41c7937c4e5ddff369fb1c5a82dda088e809c27"
+source = "git+https://github.com/fink-lang/fink.git?tag=v0.53.2#523e2cbd23e559e10eded1c1c8c28313572530fa"
 dependencies = [
  "gimli",
- "wasm-encoder 0.245.1",
- "wasmparser 0.245.1",
+ "wasm-encoder",
+ "wasmparser",
  "wat",
 ]
 
@@ -244,35 +244,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9dca005e69bf015e45577e415b9af8c67e8ee3c0e38b5b0add5aa92581ed5c"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.245.1",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.246.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61fb705ce81adde29d2a8e99d87995e39a6e927358c91398f374474746070ef7"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.246.2",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.245.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
-dependencies = [
- "bitflags",
- "hashbrown 0.16.1",
- "indexmap",
- "semver",
- "serde",
+ "wasmparser",
 ]
 
 [[package]]
@@ -282,8 +259,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71cde4757396defafd25417cfb36aa3161027d06d865b0c24baaae229aac005d"
 dependencies = [
  "bitflags",
+ "hashbrown 0.16.1",
  "indexmap",
  "semver",
+ "serde",
 ]
 
 [[package]]
@@ -296,7 +275,7 @@ dependencies = [
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.246.2",
+ "wasm-encoder",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
@@ -59,12 +59,12 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "gimli"
-version = "0.33.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19e16c5073773ccf057c282be832a59ee53ef5ff98db3aeff7f8314f52ffc196"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
 dependencies = [
  "fnv",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indexmap",
 ]
 
@@ -80,13 +80,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "2.13.1"
+name = "hashbrown"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -193,9 +199,9 @@ checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -206,9 +212,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -216,9 +222,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -229,9 +235,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -263,7 +269,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f08c9adee0428b7bddf3890fc27e015ac4b761cc608c822667102b8bfd6995e"
 dependencies = [
  "bitflags",
- "hashbrown",
+ "hashbrown 0.16.1",
  "indexmap",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.36.0", default-features = false }
+fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.53.2", default-features = false }
 wasm-bindgen = "0.2"
 
 [profile.release]

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
       }
     },
     "node_modules/@actions/http-client/node_modules/undici": {
-      "version": "6.24.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
-      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.25.0.tgz",
+      "integrity": "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -224,22 +224,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.2.tgz",
-      "integrity": "sha512-ZgcN9ToRJ80f+wNPBBKYJ+DG0jlW7ktEjYtSNkNsTrlHVMhKB8tKMdI1yIG1I9BJtykkXtqnuOjlJaEMC7J6aw==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.6.3.tgz",
+      "integrity": "sha512-sTjMtUm+bJpENU/1WlRzHEsgEHppZDZ1EtNyaOODg/sQBtMxxJzGB+MOCM+T2Q5Qe1fKBrdxUmjyRxm0r7Ez9w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.4.0"
+        "@azure/msal-common": "16.4.1"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.0.tgz",
-      "integrity": "sha512-twXt09PYtj1PffNNIAzQlrBd0DS91cdA6i1gAfzJ6BnPM4xNk5k9q/5xna7jLIjU3Jnp0slKYtucshGM8OGNAw==",
+      "version": "16.4.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.4.1.tgz",
+      "integrity": "sha512-Bl8f+w37xkXsYh7QRkAKCFGYtWMYuOVO7Lv+BxILrvGz3HbIEF22Pt0ugyj0QPOl6NLrHcnNUQ9yeew98P/5iw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -247,13 +247,13 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.1.tgz",
-      "integrity": "sha512-71grXU6+5hl+3CL3joOxlj/AW6rmhthuTlG0fRqsTrhPArQBpZuUFzCIlKOGdcafLUa/i1hBdV78ZxJdlvRA+g==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.1.2.tgz",
+      "integrity": "sha512-DoeSJ9U5KPAIZoHsPywvfEj2MhBniQe0+FSpjLUTdWoIkI999GB5USkW6nNEHnIaLVxROHXvprWA1KzdS1VQ4A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.4.0",
+        "@azure/msal-common": "16.4.1",
         "jsonwebtoken": "^9.0.0",
         "uuid": "^8.3.0"
       },
@@ -513,21 +513,21 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -536,9 +536,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2274,28 +2274,28 @@
       }
     },
     "node_modules/@textlint/ast-node-types": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.2.tgz",
-      "integrity": "sha512-fCaOxoup5LIyBEo7R1oYWE7V4bSX0KQeHh66twon9e9usaLE3ijgF8QjYsR6joCssdeCHVd0wHm7ppsEyTr6vg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-15.5.4.tgz",
+      "integrity": "sha512-bVtB6VEy9U9DpW8cTt25k5T+lz86zV5w6ImePZqY1AXzSuPhqQNT77lkMPxonXzUducEIlSvUu3o7sKw3y9+Sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/linter-formatter": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.2.tgz",
-      "integrity": "sha512-jAw7jWM8+wU9cG6Uu31jGyD1B+PAVePCvnPKC/oov+2iBPKk3ao30zc/Itmi7FvXo4oPaL9PmzPPQhyniPVgVg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/linter-formatter/-/linter-formatter-15.5.4.tgz",
+      "integrity": "sha512-D9qJedKBLmAo+kiudop4UKgSxXMi4O8U86KrCidVXZ9RsK0NSVIw6+r2rlMUOExq79iEY81FRENyzmNVRxDBsg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@azu/format-text": "^1.0.2",
         "@azu/style-format": "^1.0.1",
-        "@textlint/module-interop": "15.5.2",
-        "@textlint/resolver": "15.5.2",
-        "@textlint/types": "15.5.2",
+        "@textlint/module-interop": "15.5.4",
+        "@textlint/resolver": "15.5.4",
+        "@textlint/types": "15.5.4",
         "chalk": "^4.1.2",
         "debug": "^4.4.3",
         "js-yaml": "^4.1.1",
-        "lodash": "^4.17.23",
+        "lodash": "^4.18.1",
         "pluralize": "^2.0.0",
         "string-width": "^4.2.3",
         "strip-ansi": "^6.0.1",
@@ -2351,27 +2351,27 @@
       }
     },
     "node_modules/@textlint/module-interop": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.2.tgz",
-      "integrity": "sha512-mg6rMQ3+YjwiXCYoQXbyVfDucpTa1q5mhspd/9qHBxUq4uY6W8GU42rmT3GW0V1yOfQ9z/iRrgPtkp71s8JzXg==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/module-interop/-/module-interop-15.5.4.tgz",
+      "integrity": "sha512-JyAUd26ll3IFF87LP0uGoa8Tzw5ZKiYvGs6v8jLlzyND1lUYCI4+2oIAslrODLkf0qwoCaJrBQWM3wsw+asVGQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/resolver": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.2.tgz",
-      "integrity": "sha512-YEITdjRiJaQrGLUWxWXl4TEg+d2C7+TNNjbGPHPH7V7CCnXm+S9GTjGAL7Q2WSGJyFEKt88Jvx6XdJffRv4HEA==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/resolver/-/resolver-15.5.4.tgz",
+      "integrity": "sha512-5GUagtpQuYcmhlOzBGdmVBvDu5lKgVTjwbxtdfoidN4OIqblIxThJHHjazU+ic+/bCIIzI2JcOjHGSaRmE8Gcg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@textlint/types": {
-      "version": "15.5.2",
-      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.2.tgz",
-      "integrity": "sha512-sJOrlVLLXp4/EZtiWKWq9y2fWyZlI8GP+24rnU5avtPWBIMm/1w97yzKrAqYF8czx2MqR391z5akhnfhj2f/AQ==",
+      "version": "15.5.4",
+      "resolved": "https://registry.npmjs.org/@textlint/types/-/types-15.5.4.tgz",
+      "integrity": "sha512-mY28j2U7nrWmZbxyKnRvB8vJxJab4AxqOobLfb6iozrLelJbqxcOTvBQednadWPfAk9XWaZVMqUr9Nird3mutg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@textlint/ast-node-types": "15.5.2"
+        "@textlint/ast-node-types": "15.5.4"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2400,16 +2400,16 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.110.0.tgz",
-      "integrity": "sha512-AGuxUEpU4F4mfuQjxPPaQVyuOMhs+VT/xRok1jiHVBubHK7lBRvCuOMZG0LKUwxncrPorJ5qq/uil3IdZBd5lA==",
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.116.0.tgz",
+      "integrity": "sha512-sYHp4MO6BqJ2PD7Hjt0hlIS3tMaYsVPJrd0RUjDJ8HtOYnyJIEej0bLSccM8rE77WrC+Xox/kdBwEFDO8MsxNA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.4.tgz",
-      "integrity": "sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.5.tgz",
+      "integrity": "sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2422,9 +2422,9 @@
       }
     },
     "node_modules/@vscode/vsce": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.7.1.tgz",
-      "integrity": "sha512-OTm2XdMt2YkpSn2Nx7z2EJtSuhRHsTPYsSK59hr3v8jRArK+2UEoju4Jumn1CmpgoBLGI6ReHLJ/czYltNUW3g==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@vscode/vsce/-/vsce-3.9.0.tgz",
+      "integrity": "sha512-Dfql2kgPHpTKS+G4wTqYBKzK1KqX2gMxTC9dpnYge+aIZL+thh1Z6GXs4zOtNwo7DCPmS7BCfaHUAmNLxKiXkw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2455,7 +2455,7 @@
         "typed-rest-client": "^1.8.4",
         "url-join": "^4.0.1",
         "xml2js": "^0.5.0",
-        "yauzl": "^2.3.1",
+        "yauzl": "^3.2.1",
         "yazl": "^2.2.2"
       },
       "bin": {
@@ -2679,13 +2679,13 @@
       }
     },
     "node_modules/@vscode/vsce/node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -2932,9 +2932,9 @@
       "optional": true
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.11",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.11.tgz",
-      "integrity": "sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==",
+      "version": "2.10.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+      "integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -3018,9 +3018,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3042,9 +3042,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -3062,11 +3062,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -3183,9 +3183,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001781",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001781.tgz",
-      "integrity": "sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==",
+      "version": "1.0.30001788",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+      "integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
       "dev": true,
       "funding": [
         {
@@ -3575,9 +3575,9 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.0.tgz",
-      "integrity": "sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==",
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-8.3.1.tgz",
+      "integrity": "sha512-6gfI3otXK5Ph5DfCOI1dblr+kN3FAm5a97hYoQkqNZxOaYa5WKfXH+AnpsmS+iUH2mgVC2Cg2Qw9m5OKcmNrIg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -3631,9 +3631,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.3.0.tgz",
-      "integrity": "sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==",
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-6.4.0.tgz",
+      "integrity": "sha512-tvRg7FIBNlyPzjdG8wWRlPHQJJHI7DylhtRGeU9Lq+JuoPh5BKpPRX83ZdLrvXuOSu5Eo/e7SzOQhU4Hd2Miuw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4077,9 +4077,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.328",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.328.tgz",
-      "integrity": "sha512-QNQ5l45DzYytThO21403XN3FvK0hOkWDG8viNf6jqS42msJ8I4tGDSpBCgvDRRPnkffafiwAym2X2eHeGD2V0w==",
+      "version": "1.5.339",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+      "integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
       "dev": true,
       "license": "ISC"
     },
@@ -4504,16 +4504,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
-      }
-    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -4587,9 +4577,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "dev": true,
       "funding": [
         {
@@ -4865,13 +4855,13 @@
       }
     },
     "node_modules/glob/node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5088,9 +5078,9 @@
       }
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5808,16 +5798,16 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },
@@ -6248,9 +6238,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8348,9 +8338,9 @@
       }
     },
     "node_modules/ovsx": {
-      "version": "0.10.10",
-      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.10.tgz",
-      "integrity": "sha512-/X5J4VLKPUGGaMynW9hgvsGg9jmwsK/3RhODeA2yzdeDbb8PUSNcg5GQ9aPDJW/znlqNvAwQcXAyE+Cq0RRvAQ==",
+      "version": "0.10.11",
+      "resolved": "https://registry.npmjs.org/ovsx/-/ovsx-0.10.11.tgz",
+      "integrity": "sha512-VYYlAWO7hvcrP0EIM/Q5lCdXTumXIiGyDnSXm8ztNbGN9zCSNW6iGiJMMMUNhPRWqJjNKpo/Vc2+B4uFRy8ACg==",
       "dev": true,
       "license": "EPL-2.0",
       "dependencies": {
@@ -8695,9 +8685,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.7",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
-      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -8867,9 +8857,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -9306,9 +9296,9 @@
       }
     },
     "node_modules/semantic-release-vsce": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-6.1.1.tgz",
-      "integrity": "sha512-0rEtoVBuvCA8erArKtONZRZNmTr3BSsy1D026HCW0cNCf0KeRkNOvN/7cIZ5SOf2rLbgnCxDfjehRg9t4SzPFQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/semantic-release-vsce/-/semantic-release-vsce-6.1.3.tgz",
+      "integrity": "sha512-gddy0XKuJYJ4ltdejuiyqTerN3f1oJ16231gFDI8G8Im/aii/g/OLdRs5EGHHvnXMTDVYSKVrqPJXxwJxpNpKA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9563,14 +9553,14 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -10327,14 +10317,14 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -10509,9 +10499,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.6.tgz",
-      "integrity": "sha512-Xi4agocCbRzt0yYMZGMA6ApD7gvtUFaxm4ZmeacWI4cZxaF6C+8I8QfofC20NAePiB/IcvZmzkJ7XPa471AEtA==",
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10856,14 +10846,17 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.0.tgz",
+      "integrity": "sha512-PtGEvEP30p7sbIBJKUBjUnqgTVOyMURc4dLo9iNyAJnNIEz9pm88cCXF21w94Kg3k6RXkeZh5DHOGS0qEONvNQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
+        "pend": "~1.2.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/yauzl-promise": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,18 @@ interface ParsedDocumentHandle {
   get_diagnostics(): string;
   get_definition(line: number, col: number): Uint32Array;
   get_references(line: number, col: number): Uint32Array;
+  get_imports(): string;
+  get_module_binding(name: string): Uint32Array;
   free(): void;
+}
+
+interface ImportEntry {
+  url: string;
+  urlLine: number;
+  urlCol: number;
+  urlEndLine: number;
+  urlEndCol: number;
+  names: Array<{ name: string; line: number; col: number; endLine: number; endCol: number }>;
 }
 
 // Active document handles, keyed by URI string.
@@ -122,24 +133,125 @@ interface DiagnosticEntry {
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('fink');
 const semanticTokensChangeEmitter = new vscode.EventEmitter<void>();
 
-// Definition provider: queries cached ParsedDocument handle.
+// Resolve a relative import URL to a file URI, parse it, and find the binding.
+async function resolveImportDefinition(
+  sourceUri: vscode.Uri,
+  relativeUrl: string,
+  name: string
+): Promise<vscode.Location | undefined> {
+  if (!ParsedDocument) return undefined;
+
+  const sourceDir = vscode.Uri.joinPath(sourceUri, '..');
+  const targetUri = vscode.Uri.joinPath(sourceDir, relativeUrl);
+
+  try {
+    const bytes = await vscode.workspace.fs.readFile(targetUri);
+    const src = new TextDecoder().decode(bytes);
+    const targetDoc = new ParsedDocument(src);
+    try {
+      const binding = targetDoc.get_module_binding(name);
+      if (binding.length === 4) {
+        const range = new vscode.Range(binding[0], binding[1], binding[2], binding[3]);
+        return new vscode.Location(targetUri, range);
+      }
+    } finally {
+      targetDoc.free();
+    }
+  } catch {
+    // Target file not found or parse error — silently fall back
+  }
+  return undefined;
+}
+
+// Find which import name (if any) is at the given position.
+function findImportAt(doc: ParsedDocumentHandle, line: number, col: number): { url: string; name: string } | undefined {
+  const imports: ImportEntry[] = JSON.parse(doc.get_imports());
+  for (const imp of imports) {
+    for (const n of imp.names) {
+      if (n.line === line && n.col <= col && col < n.endCol) {
+        return { url: imp.url, name: n.name };
+      }
+    }
+  }
+  return undefined;
+}
+
+// Check if the cursor is on an import URL string, return the resolved file URI if so.
+function findImportUrlAt(doc: ParsedDocumentHandle, documentUri: vscode.Uri, line: number, col: number): vscode.Uri | undefined {
+  const imports: ImportEntry[] = JSON.parse(doc.get_imports());
+  for (const imp of imports) {
+    if (imp.urlLine === line && imp.urlCol <= col && col < imp.urlEndCol) {
+      if (imp.url.startsWith('./') || imp.url.startsWith('../')) {
+        const sourceDir = vscode.Uri.joinPath(documentUri, '..');
+        return vscode.Uri.joinPath(sourceDir, imp.url);
+      }
+    }
+  }
+  return undefined;
+}
+
+// Check if a binding site is an import binding, and if so resolve into the target module.
+async function tryResolveImport(
+  doc: ParsedDocumentHandle,
+  documentUri: vscode.Uri,
+  bindLine: number,
+  bindCol: number
+): Promise<vscode.Location | undefined> {
+  const imp = findImportAt(doc, bindLine, bindCol);
+  if (imp && (imp.url.startsWith('./') || imp.url.startsWith('../'))) {
+    return resolveImportDefinition(documentUri, imp.url, imp.name);
+  }
+  return undefined;
+}
+
+// Definition provider: follows imports to the target module.
+// For imported names, F12 jumps to where the name is defined in the target file.
+// For local names, F12 jumps to the local binding site.
 const definitionProvider: vscode.DefinitionProvider = {
-  provideDefinition(
+  async provideDefinition(
     document: vscode.TextDocument,
     position: vscode.Position
-  ): vscode.Definition | undefined {
+  ): Promise<vscode.Definition | undefined> {
     const doc = getDoc(document);
     if (!doc) return undefined;
+
+    // Cmd+click on import URL string → open the file
+    const importFileUri = findImportUrlAt(doc, document.uri, position.line, position.character);
+    if (importFileUri) {
+      return new vscode.Location(importFileUri, new vscode.Position(0, 0));
+    }
 
     if (debug) console.time('fink:definition');
     const data = doc.get_definition(position.line, position.character);
     if (debug) console.timeEnd('fink:definition');
 
+    if (data.length !== 4) return undefined;
+
+    const defRange = new vscode.Range(data[0], data[1], data[2], data[3]);
+
+    // Try to follow import: check if the binding site is an import destructure
+    const targetLocation = await tryResolveImport(doc, document.uri, defRange.start.line, defRange.start.character);
+    if (targetLocation) return targetLocation;
+
+    return new vscode.Location(document.uri, defRange);
+  }
+};
+
+// Declaration provider: always returns the local binding site.
+// For imported names, this is {foo} = import './spam.fnk'.
+const declarationProvider: vscode.DeclarationProvider = {
+  provideDeclaration(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.Declaration | undefined {
+    const doc = getDoc(document);
+    if (!doc) return undefined;
+
+    const data = doc.get_definition(position.line, position.character);
     if (data.length === 4) {
       const defRange = new vscode.Range(data[0], data[1], data[2], data[3]);
       return new vscode.Location(document.uri, defRange);
     }
-
     return undefined;
   }
 };
@@ -288,6 +400,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   context.subscriptions.push(
     vscode.languages.registerDefinitionProvider('fink', definitionProvider)
+  );
+
+  context.subscriptions.push(
+    vscode.languages.registerDeclarationProvider('fink', declarationProvider)
   );
 
   context.subscriptions.push(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,9 +293,68 @@ fn ast_loc(node: &Node) -> Loc {
 /// Sorted by (line, col) for binary search.
 struct IdentEntry {
     loc: Loc,
+    name: String,
     /// The BindId this ident resolves to (if it's a reference),
     /// or the BindId it defines (if it's a binding site).
     bind_id: Option<BindId>,
+    /// True if this ident is the binding site (not a reference).
+    is_binding_site: bool,
+}
+
+/// An imported name with its location in the import destructure.
+struct ImportedName {
+    name: String,
+    loc: Loc,
+}
+
+/// An import statement: URL + its location + list of imported names with their locations.
+struct ImportInfo {
+    url: String,
+    url_loc: Loc,
+    names: Vec<ImportedName>,
+}
+
+/// Extract import info from the raw parsed AST.
+/// Looks for: Bind { lhs: LitRec { Arm { Patterns([Ident]) } }, rhs: Apply { Ident("import"), [LitStr] } }
+fn extract_imports(ast: &Ast) -> Vec<ImportInfo> {
+    let root = ast.nodes.get(ast.root);
+    let NodeKind::Module { exprs, .. } = &root.kind else { return vec![] };
+
+    let mut imports = Vec::new();
+    for expr_id in exprs.items.iter() {
+        let expr = ast.nodes.get(*expr_id);
+        let NodeKind::Bind { lhs, rhs, .. } = &expr.kind else { continue };
+
+        // Check rhs is Apply { func: Ident("import"), args: [LitStr { content }] }
+        let rhs_node = ast.nodes.get(*rhs);
+        let NodeKind::Apply { func, args } = &rhs_node.kind else { continue };
+        let func_node = ast.nodes.get(*func);
+        if !matches!(&func_node.kind, NodeKind::Ident("import")) { continue }
+        let Some(first_arg_id) = args.items.first() else { continue };
+        let arg_node = ast.nodes.get(*first_arg_id);
+        let NodeKind::LitStr { content: url, .. } = &arg_node.kind else { continue };
+
+        // Extract names from lhs: LitRec { items: [Ident("foo"), Ident("bar"), ...] }
+        // Bare shorthand {foo} produces direct Ident children, not Arm nodes.
+        let lhs_node = ast.nodes.get(*lhs);
+        let NodeKind::LitRec { items, .. } = &lhs_node.kind else { continue };
+
+        let mut names = Vec::new();
+        for item_id in items.items.iter() {
+            let item_node = ast.nodes.get(*item_id);
+            if let NodeKind::Ident(name) = &item_node.kind {
+                names.push(ImportedName {
+                    name: name.to_string(),
+                    loc: ast_loc(item_node),
+                });
+            }
+        }
+
+        if !names.is_empty() {
+            imports.push(ImportInfo { url: url.clone(), url_loc: ast_loc(arg_node), names });
+        }
+    }
+    imports
 }
 
 /// Stateful parsed document - parse once, query many times.
@@ -316,6 +375,9 @@ pub struct ParsedDocument {
 
     /// Identifier nodes sorted by position, for cursor hit-testing.
     idents: Vec<IdentEntry>,
+
+    /// Import statements extracted from the raw AST.
+    imports: Vec<ImportInfo>,
 }
 
 #[wasm_bindgen]
@@ -345,12 +407,13 @@ impl ParsedDocument {
         }
 
         // --- Parse + desugar (partial-apply + index + scopes) ---
-        let empty_doc = |diag_entries: Vec<String>, semantic_tokens: Vec<u32>| ParsedDocument {
+        let empty_doc = |diag_entries: Vec<String>, semantic_tokens: Vec<u32>, imports: Vec<ImportInfo>| ParsedDocument {
             semantic_tokens,
             diagnostics: format!("[{}]", diag_entries.join(",")),
             bind_locs: vec![],
             bind_refs: vec![],
             idents: vec![],
+            imports,
         };
 
         let parsed = match passes::parse(src, "") {
@@ -364,9 +427,12 @@ impl ParsedDocument {
                 diag_entries.push(format!(
                     r#"{{"line":{line},"col":{col},"endLine":{end_line},"endCol":{end_col},"message":"{msg}","source":"parser","severity":"error"}}"#
                 ));
-                return empty_doc(diag_entries, vec![]);
+                return empty_doc(diag_entries, vec![], vec![]);
             }
         };
+
+        // --- Extract imports from raw AST (before desugar consumes it) ---
+        let imports = extract_imports(&parsed);
 
         // --- Semantic tokens (from raw parsed AST, before desugar) ---
         let mut raw_tokens = Vec::new();
@@ -377,7 +443,7 @@ impl ParsedDocument {
         let root_node = parsed.nodes.get(parsed.root);
         let is_empty = matches!(&root_node.kind, NodeKind::Module { exprs, .. } if exprs.items.is_empty());
         if is_empty {
-            return empty_doc(diag_entries, semantic_tokens);
+            return empty_doc(diag_entries, semantic_tokens, imports);
         }
 
         let desugared = match passes::desugar(parsed) {
@@ -391,7 +457,7 @@ impl ParsedDocument {
                 diag_entries.push(format!(
                     r#"{{"line":{line},"col":{col},"endLine":{end_line},"endCol":{end_col},"message":"{msg}","source":"desugar","severity":"error"}}"#
                 ));
-                return empty_doc(diag_entries, semantic_tokens);
+                return empty_doc(diag_entries, semantic_tokens, imports);
             }
         };
 
@@ -436,7 +502,7 @@ impl ParsedDocument {
         for i in 0..ast.nodes.len() {
             let ast_id = AstId(i as u32);
             let Some(node) = ast.nodes.try_get(ast_id) else { continue };
-            if !matches!(&node.kind, NodeKind::Ident(_)) { continue; }
+            let NodeKind::Ident(name) = &node.kind else { continue };
 
             let loc = ast_loc(node);
 
@@ -451,9 +517,10 @@ impl ParsedDocument {
 
             // Determine the BindId: either from resolution (reference) or
             // from the reverse map (binding site)
+            let is_binding_site = ast_to_bind.contains_key(&ast_id);
             let entry_bind_id = ref_bind_id.or_else(|| ast_to_bind.get(&ast_id).copied());
 
-            idents.push(IdentEntry { loc, bind_id: entry_bind_id });
+            idents.push(IdentEntry { loc, name: name.to_string(), bind_id: entry_bind_id, is_binding_site });
         }
 
         // --- Unresolved name diagnostics ---
@@ -528,6 +595,7 @@ impl ParsedDocument {
             bind_locs,
             bind_refs,
             idents,
+            imports,
         }
     }
 
@@ -547,6 +615,40 @@ impl ParsedDocument {
         let Some(bind_id) = self.find_bind_at(line, col) else { return vec![] };
         let Some(loc) = self.bind_locs[bind_id.0 as usize] else { return vec![] };
         vec![loc.line, loc.col, loc.end_line, loc.end_col]
+    }
+
+    /// Return JSON import metadata.
+    /// Format: [{"url":"./foo.fnk","names":[{"name":"x","line":0,"col":1,"endLine":0,"endCol":2},...]}]
+    pub fn get_imports(&self) -> String {
+        let mut entries: Vec<String> = Vec::new();
+        for imp in &self.imports {
+            let url = imp.url.replace('\\', "\\\\").replace('"', "\\\"");
+            let names: Vec<String> = imp.names.iter().map(|n| {
+                let name = n.name.replace('\\', "\\\\").replace('"', "\\\"");
+                format!(
+                    r#"{{"name":"{name}","line":{},"col":{},"endLine":{},"endCol":{}}}"#,
+                    n.loc.line, n.loc.col, n.loc.end_line, n.loc.end_col
+                )
+            }).collect();
+            let ul = &imp.url_loc;
+            entries.push(format!(
+                r#"{{"url":"{url}","urlLine":{},"urlCol":{},"urlEndLine":{},"urlEndCol":{},"names":[{}]}}"#,
+                ul.line, ul.col, ul.end_line, ul.end_col, names.join(",")
+            ));
+        }
+        format!("[{}]", entries.join(","))
+    }
+
+    /// Look up a module-level binding by name.
+    /// Returns [line, col, end_line, end_col] or empty if not found.
+    /// Used to find where a name is exported in a target module.
+    pub fn get_module_binding(&self, name: &str) -> Vec<u32> {
+        for entry in &self.idents {
+            if entry.is_binding_site && entry.name == name {
+                return vec![entry.loc.line, entry.loc.col, entry.loc.end_line, entry.loc.end_col];
+            }
+        }
+        vec![]
     }
 
     /// Find all references to the identifier at (line, col), including the binding site.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use wasm_bindgen::prelude::*;
 
-use fink::ast::{AstId, Node, NodeKind};
+use fink::ast::{Ast, AstId, Node, NodeKind};
 use fink::lexer::{self, TokenKind};
 use fink::passes;
 use fink::passes::scopes::{self, BindId, BindOrigin, RefKind, ScopeEvent, ScopeKind};
@@ -27,9 +27,10 @@ struct RawToken {
 
 /// Resolve the callee of a function application.
 /// Follows Member.rhs chain to find the actual callee node.
-fn resolve_callee<'a>(node: &'a Node<'a>) -> &'a Node<'a> {
+fn resolve_callee<'a>(ast: &'a Ast<'a>, id: AstId) -> &'a Node<'a> {
+    let node = ast.nodes.get(id);
     match &node.kind {
-        NodeKind::Member { rhs, .. } => resolve_callee(rhs),
+        NodeKind::Member { rhs, .. } => resolve_callee(ast, *rhs),
         _ => node,
     }
 }
@@ -50,16 +51,18 @@ fn emit_token(tokens: &mut Vec<RawToken>, node: &Node, token_type: u32, modifier
 }
 
 
-fn collect_tokens<'src>(node: &'src Node<'src>, tokens: &mut Vec<RawToken>) {
+fn collect_tokens<'src>(ast: &'src Ast<'src>, id: AstId, tokens: &mut Vec<RawToken>) {
+    let node = ast.nodes.get(id);
     match &node.kind {
         NodeKind::Apply { func, args } => {
-            let callee = resolve_callee(func);
+            let callee = resolve_callee(ast, *func);
             match &callee.kind {
                 NodeKind::Ident(_) => {
                     // Tagged literal: callee adjacent to first arg
                     // Prefix: foo'bar' (callee end == arg start) → tag.left
                     // Postfix: 123foo (arg end == callee start) → tag.right
-                    let tag_kind = args.items.first().and_then(|first_arg| {
+                    let tag_kind = args.items.first().and_then(|first_arg_id| {
+                        let first_arg = ast.nodes.get(*first_arg_id);
                         if callee.loc.end.idx == first_arg.loc.start.idx {
                             Some(TOKEN_TAG_LEFT)
                         } else if first_arg.loc.end.idx == callee.loc.start.idx {
@@ -97,26 +100,30 @@ fn collect_tokens<'src>(node: &'src Node<'src>, tokens: &mut Vec<RawToken>) {
                 _ => {}
             }
             // Recurse into func and args
-            collect_tokens(func, tokens);
-            for arg in &args.items {
-                collect_tokens(arg, tokens);
+            collect_tokens(ast, *func, tokens);
+            for arg_id in args.items.iter() {
+                collect_tokens(ast, *arg_id, tokens);
             }
         }
 
         NodeKind::Pipe(children) => {
-            for child in &children.items {
+            for child_id in children.items.iter() {
+                let child = ast.nodes.get(*child_id);
                 if matches!(&child.kind, NodeKind::Ident(_)) {
                     emit_token(tokens, child, TOKEN_FUNCTION, 0);
                 }
-                collect_tokens(child, tokens);
+                collect_tokens(ast, *child_id, tokens);
             }
         }
 
         NodeKind::LitRec { items: children, .. } => {
-            for child in &children.items {
+            for child_id in children.items.iter() {
+                let child = ast.nodes.get(*child_id);
                 if let NodeKind::Arm { lhs, body, .. } = &child.kind {
-                    if let NodeKind::Patterns(pats) = &lhs.kind {
-                        if let Some(first_lhs) = pats.items.first() {
+                    let lhs_node = ast.nodes.get(*lhs);
+                    if let NodeKind::Patterns(pats) = &lhs_node.kind {
+                        if let Some(first_lhs_id) = pats.items.first() {
+                            let first_lhs = ast.nodes.get(*first_lhs_id);
                             if matches!(&first_lhs.kind, NodeKind::Ident(_)) {
                                 if body.items.is_empty() {
                                     emit_token(tokens, first_lhs, TOKEN_VARIABLE, MOD_READONLY);
@@ -127,98 +134,98 @@ fn collect_tokens<'src>(node: &'src Node<'src>, tokens: &mut Vec<RawToken>) {
                         }
                     }
                     // Recurse into arm body
-                    for expr in body.items.iter() {
-                        collect_tokens(expr, tokens);
+                    for expr_id in body.items.iter() {
+                        collect_tokens(ast, *expr_id, tokens);
                     }
                 } else {
-                    collect_tokens(child, tokens);
+                    collect_tokens(ast, *child_id, tokens);
                 }
             }
         }
 
         // --- recurse into all other container nodes ---
 
-        NodeKind::Module(children)
+        NodeKind::Module { exprs: children, .. }
         | NodeKind::LitSeq { items: children, .. }
         | NodeKind::Patterns(children) => {
-            for child in &children.items {
-                collect_tokens(child, tokens);
+            for child_id in children.items.iter() {
+                collect_tokens(ast, *child_id, tokens);
             }
         }
 
         NodeKind::StrTempl { children, .. }
         | NodeKind::StrRawTempl { children, .. } => {
-            for child in children {
-                collect_tokens(child, tokens);
+            for child_id in children.iter() {
+                collect_tokens(ast, *child_id, tokens);
             }
         }
 
         NodeKind::InfixOp { lhs, rhs, .. } => {
-            collect_tokens(lhs, tokens);
-            collect_tokens(rhs, tokens);
+            collect_tokens(ast, *lhs, tokens);
+            collect_tokens(ast, *rhs, tokens);
         }
 
         NodeKind::Bind { lhs, rhs, .. }
         | NodeKind::BindRight { lhs, rhs, .. }
         | NodeKind::Member { lhs, rhs, .. } => {
-            collect_tokens(lhs, tokens);
-            collect_tokens(rhs, tokens);
+            collect_tokens(ast, *lhs, tokens);
+            collect_tokens(ast, *rhs, tokens);
         }
 
         NodeKind::UnaryOp { operand, .. } => {
-            collect_tokens(operand, tokens);
+            collect_tokens(ast, *operand, tokens);
         }
 
         NodeKind::Group { inner, .. }
-        | NodeKind::Try(inner)
-        | NodeKind::Yield(inner) => {
-            collect_tokens(inner, tokens);
+        | NodeKind::Try(inner) => {
+            collect_tokens(ast, *inner, tokens);
         }
 
         NodeKind::Spread { inner: Some(inner), .. } => {
-            collect_tokens(inner, tokens);
+            collect_tokens(ast, *inner, tokens);
         }
 
         NodeKind::Fn { params, body, .. } => {
-            collect_tokens(params, tokens);
-            for expr in &body.items {
-                collect_tokens(expr, tokens);
+            collect_tokens(ast, *params, tokens);
+            for expr_id in body.items.iter() {
+                collect_tokens(ast, *expr_id, tokens);
             }
         }
 
         NodeKind::Match { subjects, arms, .. } => {
-            for subj in &subjects.items {
-                collect_tokens(subj, tokens);
+            for subj_id in subjects.items.iter() {
+                collect_tokens(ast, *subj_id, tokens);
             }
-            for arm in &arms.items {
-                collect_tokens(arm, tokens);
+            for arm_id in arms.items.iter() {
+                collect_tokens(ast, *arm_id, tokens);
             }
         }
 
         NodeKind::Arm { lhs, body, .. } => {
             // Arms not inside LitRec — just recurse
-            collect_tokens(lhs, tokens);
-            for expr in &body.items {
-                collect_tokens(expr, tokens);
+            collect_tokens(ast, *lhs, tokens);
+            for expr_id in body.items.iter() {
+                collect_tokens(ast, *expr_id, tokens);
             }
         }
 
         NodeKind::Block { name, params, body, .. } => {
             // Emit namespace token for the block name
-            if matches!(&name.kind, NodeKind::Ident(_)) {
-                emit_token(tokens, name, TOKEN_BLOCK_NAME, 0);
+            let name_node = ast.nodes.get(*name);
+            if matches!(&name_node.kind, NodeKind::Ident(_)) {
+                emit_token(tokens, name_node, TOKEN_BLOCK_NAME, 0);
             }
-            collect_tokens(name, tokens);
-            collect_tokens(params, tokens);
-            for expr in &body.items {
-                collect_tokens(expr, tokens);
+            collect_tokens(ast, *name, tokens);
+            collect_tokens(ast, *params, tokens);
+            for expr_id in body.items.iter() {
+                collect_tokens(ast, *expr_id, tokens);
             }
         }
 
         NodeKind::ChainedCmp(parts) => {
-            for part in parts {
-                if let fink::ast::CmpPart::Operand(node) = part {
-                    collect_tokens(node, tokens);
+            for part in parts.iter() {
+                if let fink::ast::CmpPart::Operand(operand_id) = part {
+                    collect_tokens(ast, *operand_id, tokens);
                 }
             }
         }
@@ -346,7 +353,7 @@ impl ParsedDocument {
             idents: vec![],
         };
 
-        let parsed = match passes::parse(src) {
+        let parsed = match passes::parse(src, "") {
             Ok(r) => r,
             Err(e) => {
                 let line = e.loc.start.line.saturating_sub(1);
@@ -363,11 +370,12 @@ impl ParsedDocument {
 
         // --- Semantic tokens (from raw parsed AST, before desugar) ---
         let mut raw_tokens = Vec::new();
-        collect_tokens(&parsed.result.root, &mut raw_tokens);
+        collect_tokens(&parsed, parsed.root, &mut raw_tokens);
         let semantic_tokens = delta_encode(raw_tokens);
 
         // --- Empty document: skip desugar ---
-        let is_empty = matches!(&parsed.result.root.kind, NodeKind::Module(exprs) if exprs.items.is_empty());
+        let root_node = parsed.nodes.get(parsed.root);
+        let is_empty = matches!(&root_node.kind, NodeKind::Module { exprs, .. } if exprs.items.is_empty());
         if is_empty {
             return empty_doc(diag_entries, semantic_tokens);
         }
@@ -387,7 +395,7 @@ impl ParsedDocument {
             }
         };
 
-        let ast_index = &desugared.ast_index;
+        let ast = &desugared.ast;
         let scope_result = &desugared.scope;
 
         // --- Build bind location table ---
@@ -398,8 +406,7 @@ impl ParsedDocument {
             let bind_info = scope_result.binds.get(bind_id);
             let loc = match bind_info.origin {
                 BindOrigin::Ast(ast_id) => {
-                    ast_index.try_get(ast_id)
-                        .and_then(|opt| *opt)
+                    ast.nodes.try_get(ast_id)
                         .map(|node| ast_loc(node))
                 }
                 BindOrigin::Builtin(_) => None,
@@ -426,9 +433,9 @@ impl ParsedDocument {
         let mut used_binds: HashSet<u32> = HashSet::new();
 
         // Walk all AST nodes to find Ident nodes
-        for i in 0..ast_index.len() {
+        for i in 0..ast.nodes.len() {
             let ast_id = AstId(i as u32);
-            let Some(Some(node)) = ast_index.try_get(ast_id) else { continue };
+            let Some(node) = ast.nodes.try_get(ast_id) else { continue };
             if !matches!(&node.kind, NodeKind::Ident(_)) { continue; }
 
             let loc = ast_loc(node);
@@ -457,7 +464,7 @@ impl ParsedDocument {
                 for event in events {
                     if let ScopeEvent::Ref(ref_info) = event {
                         if ref_info.kind == RefKind::Unresolved {
-                            if let Some(Some(node)) = ast_index.try_get(ref_info.ast_id) {
+                            if let Some(node) = ast.nodes.try_get(ref_info.ast_id) {
                                 let line = node.loc.start.line.saturating_sub(1);
                                 let col = node.loc.start.col;
                                 let end_line = node.loc.end.line.saturating_sub(1);
@@ -497,7 +504,7 @@ impl ParsedDocument {
             if scope_info.kind == ScopeKind::Module { continue; }
 
             let BindOrigin::Ast(ast_id) = bind_info.origin else { continue };
-            let Some(Some(node)) = ast_index.try_get(ast_id) else { continue };
+            let Some(node) = ast.nodes.try_get(ast_id) else { continue };
 
             // Only warn for user-written Ident bindings
             let NodeKind::Ident(name) = &node.kind else { continue };


### PR DESCRIPTION
## Summary
- Upgrade non-fink deps: wasm-bindgen 0.2.118, @types/vscode 1.116.0, semantic-release-vsce 6.1.3
- Upgrade fink v0.36.0 → v0.53.2 — adapt to flat arena AST (all child refs are AstId, NodeKind::Yield removed, passes::parse takes url param)
- Cross-module go-to-definition for imports: F12 on an imported name jumps to the definition in the target file, Go to Declaration returns the local import binding, Cmd+click on the import URL opens the file

## Test plan
- [x] Clean build passes (`make clean && make build`)
- [x] Smoke test: semantic tokens, diagnostics, go-to-def, find-references still work for local names
- [x] Import go-to-def: F12 on `foo` in `{foo} = import './bar.fnk'` jumps to `foo` definition in `bar.fnk`
- [x] Import declaration: Go to Declaration on imported `foo` jumps to the local import binding
- [x] Import URL click: Cmd+click on `'./bar.fnk'` opens the file