### PR TITLE
feat: sourcemap highlight for fink/WAT test expectations (fink v0.54.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,7 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 [[package]]
 name = "fink"
 version = "0.0.0"
-source = "git+https://github.com/fink-lang/fink.git?tag=v0.53.2#523e2cbd23e559e10eded1c1c8c28313572530fa"
+source = "git+https://github.com/fink-lang/fink.git?tag=v0.54.0#9d62a38f70f80eb22fd4a3c4bf719728e12fa0d8"
 dependencies = [
  "gimli",
  "wasm-encoder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.53.2", default-features = false }
+fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.54.0", default-features = false }
 wasm-bindgen = "0.2"
 
 [profile.release]

--- a/scripts/smoke-sm.mjs
+++ b/scripts/smoke-sm.mjs
@@ -1,0 +1,54 @@
+// Smoke test for get_sm_mappings — load the wasm module and print the decoded
+// mappings for a given fink test file. Intended for ad-hoc verification.
+//
+// Usage:
+//   node scripts/smoke-sm.mjs <path-to-fink-test-file>
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const repoRoot = resolve(__dirname, '..');
+
+const target = process.argv[2];
+if (!target) {
+  console.error('usage: node scripts/smoke-sm.mjs <fink-test-file>');
+  process.exit(1);
+}
+
+const wasmJsPath = resolve(repoRoot, 'build/pkg/wasm/fink_wasm.js');
+const wasmBinPath = resolve(repoRoot, 'build/pkg/wasm/fink_wasm_bg.wasm');
+
+const wasmModule = await import(wasmJsPath);
+const wasmBytes = readFileSync(wasmBinPath);
+await wasmModule.default(wasmBytes);
+
+const src = readFileSync(target, 'utf8');
+
+// Warm-up + timing.
+for (let i = 0; i < 3; i++) wasmModule.get_sm_mappings(src);
+const iters = 50;
+const t0 = performance.now();
+for (let i = 0; i < iters; i++) wasmModule.get_sm_mappings(src);
+const elapsed = performance.now() - t0;
+console.log(`size=${src.length}B, avg=${(elapsed / iters).toFixed(2)}ms over ${iters} iters`);
+
+const json = wasmModule.get_sm_mappings(src);
+const groups = JSON.parse(json);
+
+console.log(`found ${groups.length} sm group(s)`);
+const showAll = process.argv.includes('--all');
+for (const [i, g] of groups.entries()) {
+  console.log(`  group ${i}: ${g.mappings.length} mapping(s)`);
+  const limit = showAll ? g.mappings.length : 5;
+  for (const m of g.mappings.slice(0, limit)) {
+    const outStr = `out=${m.out.line}:${m.out.col}-${m.out.endLine}:${m.out.endCol}`;
+    const srcStr = m.src
+      ? `src=${m.src.line}:${m.src.col}-${m.src.endLine}:${m.src.endCol}`
+      : 'src=<none>';
+    console.log(`    ${outStr}  ${srcStr}`);
+  }
+  if (!showAll && g.mappings.length > 5) console.log(`    ... ${g.mappings.length - 5} more`);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,7 @@ const legend = new vscode.SemanticTokensLegend(tokenTypes, tokenModifiers);
 let ParsedDocument: {
   new(src: string): ParsedDocumentHandle;
 } | undefined;
+let getSmMappings: ((src: string) => string) | undefined;
 let debug = false;
 let statusBarItem: vscode.StatusBarItem;
 
@@ -66,6 +67,8 @@ function updateDoc(document: vscode.TextDocument): void {
   });
   diagnosticCollection.set(document.uri, diagnostics);
   semanticTokensChangeEmitter.fire();
+
+  updateSmMappings(document);
 }
 
 async function loadWasm(context: vscode.ExtensionContext): Promise<void> {
@@ -86,6 +89,7 @@ async function loadWasm(context: vscode.ExtensionContext): Promise<void> {
   const wasmModule = await import(dataUrl);
   await wasmModule.default(wasmBytes.buffer);
   ParsedDocument = wasmModule.ParsedDocument;
+  getSmMappings = wasmModule.get_sm_mappings;
 }
 
 function setStatus(ok: boolean): void {
@@ -362,6 +366,112 @@ const provider: vscode.DocumentSemanticTokensProvider = {
   }
 };
 
+// --- Source-map highlighting for fink compiler test files ---
+
+interface SmRange {
+  line: number;
+  col: number;
+  endLine: number;
+  endCol: number;
+}
+interface SmMapping {
+  out: SmRange;
+  src?: SmRange;
+}
+interface SmGroup {
+  mappings: SmMapping[];
+}
+
+const smCache = new Map<string, SmGroup[]>();
+
+function updateSmMappings(document: vscode.TextDocument): void {
+  if (!getSmMappings) return;
+  const key = document.uri.toString();
+  try {
+    const json = getSmMappings(document.getText());
+    smCache.set(key, JSON.parse(json));
+  } catch {
+    smCache.delete(key);
+  }
+}
+
+const smOutDecoration = vscode.window.createTextEditorDecorationType({
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: new vscode.ThemeColor('editorWarning.foreground'),
+  borderRadius: '2px'
+});
+const smSrcDecoration = vscode.window.createTextEditorDecorationType({
+  borderWidth: '1px',
+  borderStyle: 'solid',
+  borderColor: new vscode.ThemeColor('editorInfo.foreground'),
+  borderRadius: '2px'
+});
+
+function rangeFromSm(r: SmRange): vscode.Range {
+  return new vscode.Range(r.line, r.col, r.endLine, r.endCol);
+}
+
+function rangeContains(r: SmRange, pos: vscode.Position): boolean {
+  const afterStart = pos.line > r.line || (pos.line === r.line && pos.character >= r.col);
+  const beforeEnd = pos.line < r.endLine || (pos.line === r.endLine && pos.character < r.endCol);
+  return afterStart && beforeEnd;
+}
+
+function rangeSize(r: SmRange): number {
+  // Used only for smallest-span tie-breaking. Line diff dominates when ranges
+  // span multiple lines; otherwise char diff.
+  if (r.line === r.endLine) return r.endCol - r.col;
+  return (r.endLine - r.line) * 100000 + (r.endCol - r.col);
+}
+
+function findSmallestMappingAt(groups: SmGroup[], pos: vscode.Position): SmMapping | undefined {
+  // Prefer the smallest POSITIVE-size span. Zero-width spans (two mappings
+  // share the same output offset) only fire if there's no positive match.
+  let best: SmMapping | undefined;
+  let bestSize = Infinity;
+  let bestFallback: SmMapping | undefined;
+  for (const group of groups) {
+    for (const m of group.mappings) {
+      const inOut = rangeContains(m.out, pos);
+      const inSrc = m.src ? rangeContains(m.src, pos) : false;
+      if (!inOut && !inSrc) continue;
+      const sizeOut = inOut ? rangeSize(m.out) : Infinity;
+      const sizeSrc = inSrc && m.src ? rangeSize(m.src) : Infinity;
+      const size = Math.min(sizeOut, sizeSrc);
+      if (size > 0 && size < bestSize) {
+        bestSize = size;
+        best = m;
+      } else if (size === 0 && !bestFallback) {
+        bestFallback = m;
+      }
+    }
+  }
+  return best ?? bestFallback;
+}
+
+function applySmHighlight(editor: vscode.TextEditor, pos: vscode.Position): void {
+  const groups = smCache.get(editor.document.uri.toString());
+  if (!groups || groups.length === 0) {
+    editor.setDecorations(smOutDecoration, []);
+    editor.setDecorations(smSrcDecoration, []);
+    return;
+  }
+  const m = findSmallestMappingAt(groups, pos);
+  if (!m) {
+    editor.setDecorations(smOutDecoration, []);
+    editor.setDecorations(smSrcDecoration, []);
+    return;
+  }
+  editor.setDecorations(smOutDecoration, [rangeFromSm(m.out)]);
+  editor.setDecorations(smSrcDecoration, m.src ? [rangeFromSm(m.src)] : []);
+}
+
+function clearSmHighlight(editor: vscode.TextEditor): void {
+  editor.setDecorations(smOutDecoration, []);
+  editor.setDecorations(smSrcDecoration, []);
+}
+
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   debug = context.extensionMode === vscode.ExtensionMode.Development;
 
@@ -445,6 +555,40 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       docs.get(key)?.free();
       docs.delete(key);
       diagnosticCollection.delete(doc.uri);
+      smCache.delete(key);
+    })
+  );
+
+  // Free sm decorations on shutdown.
+  context.subscriptions.push(smOutDecoration, smSrcDecoration);
+
+  // Drive sm highlighting from cursor moves in fink editors.
+  context.subscriptions.push(
+    vscode.window.onDidChangeTextEditorSelection(e => {
+      if (e.textEditor.document.languageId !== 'fink') return;
+      applySmHighlight(e.textEditor, e.selections[0].active);
+    })
+  );
+
+  // Also respond to hover — register a hover provider that, as a side effect,
+  // paints the decoration. Return undefined so we don't actually show a hover
+  // tooltip (decoration is the UI).
+  context.subscriptions.push(
+    vscode.languages.registerHoverProvider('fink', {
+      provideHover(document, position) {
+        const editor = vscode.window.visibleTextEditors.find(
+          e => e.document.uri.toString() === document.uri.toString()
+        );
+        if (editor) applySmHighlight(editor, position);
+        return undefined;
+      }
+    })
+  );
+
+  // Clear decorations when switching editors.
+  context.subscriptions.push(
+    vscode.window.onDidChangeActiveTextEditor(editor => {
+      if (editor) clearSmHighlight(editor);
     })
   );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ use fink::ast::{Ast, AstId, Node, NodeKind};
 use fink::lexer::{self, TokenKind};
 use fink::passes;
 use fink::passes::scopes::{self, BindId, BindOrigin, RefKind, ScopeEvent, ScopeKind};
+use fink::sourcemap::native::SourceMap;
 
 // Token type indices (must match TypeScript legend)
 const TOKEN_FUNCTION: u32 = 0;
@@ -690,4 +691,607 @@ impl ParsedDocument {
         }
         None
     }
+}
+
+// ---------------------------------------------------------------------------
+// Source-map highlighting support for fink compiler test files.
+//
+// Test files contain pairs of blocks:
+//
+//   test 'name', fn:
+//     expect gen_wat ƒink:
+//       <input>
+//     | equals wat":
+//       <expected output>
+//       ;; sm:<base64>
+//
+// or with a ƒink expectation:
+//
+//     | equals ƒink:
+//       <expected output>
+//       # sm:<base64>
+//
+// `get_sm_mappings(src)` finds every such pair and returns the decoded
+// mappings as document-absolute line/col ranges, so the TS side can light up
+// matching spans on hover/click without decoding the payload itself.
+// ---------------------------------------------------------------------------
+
+/// A position→(line,col) lookup over a block's raw source text, accounting for
+/// dedent: source indices skip the block's leading indentation on each line.
+///
+/// We walk the block content once, building a table that maps every byte of
+/// the dedented string to the absolute (line, col) in the original source.
+struct BlockMap {
+    /// For each byte in the dedented content, its absolute doc line (0-based).
+    lines: Vec<u32>,
+    /// For each byte in the dedented content, its absolute doc column (0-based, UTF-16 units).
+    cols: Vec<u32>,
+    /// Total length of the dedented content in bytes.
+    dedented_len: u32,
+    /// Absolute doc line of the position one past the last char.
+    end_line: u32,
+    /// Absolute doc UTF-16 column of the position one past the last char.
+    end_col: u32,
+}
+
+impl BlockMap {
+    /// Build a map for a block whose raw source text is `block_text`, starting
+    /// at absolute doc line `start_line` and UTF-16 column `start_col`. The
+    /// dedent `strip` is the number of leading-whitespace characters removed
+    /// from each content line (except possibly blank lines, which are
+    /// preserved as empty).
+    ///
+    /// `block_text` may begin mid-line (the first line's indent is NOT
+    /// stripped) or at the start of a line. In fink's block body case, the
+    /// first body line starts after the block header, so we always pass the
+    /// body text starting at the first body-content character.
+    ///
+    /// The map is byte-indexed (one entry per UTF-8 byte of the dedented
+    /// content) but stores columns in UTF-16 units to match VSCode's
+    /// position encoding.
+    fn build(block_text: &str, start_line: u32, start_col: u32, strip: u32) -> Self {
+        let mut lines = Vec::with_capacity(block_text.len());
+        let mut cols = Vec::with_capacity(block_text.len());
+
+        let mut line = start_line;
+        let mut col = start_col;
+        let mut first_line = true;
+        let mut at_line_start = false;
+
+        // Walk character by character; for each char, push (line, col) once
+        // per UTF-8 byte it occupies so that dedented byte offsets map back
+        // to the correct UTF-16 column.
+        let mut chars = block_text.char_indices().peekable();
+        while let Some((_byte_pos, ch)) = chars.next() {
+            // At start of a non-first line, skip up to `strip` spaces/tabs.
+            if at_line_start {
+                at_line_start = false;
+                let mut skipped = 0u32;
+                let mut current = ch;
+                loop {
+                    if skipped >= strip { break; }
+                    if current != ' ' && current != '\t' { break; }
+                    skipped += 1;
+                    col += 1;
+                    // Consume; peek the next to continue the loop.
+                    match chars.next() {
+                        Some((_, next_ch)) => current = next_ch,
+                        None => {
+                            let dl = lines.len() as u32;
+                            return BlockMap {
+                                lines,
+                                cols,
+                                dedented_len: dl,
+                                end_line: line,
+                                end_col: col,
+                            };
+                        }
+                    }
+                }
+                // `current` now points at the first un-skipped char.
+                // Emit it and fall through to normal handling.
+                if current == '\n' {
+                    // Line was blank (or only had whitespace <= strip); emit newline.
+                    lines.push(line);
+                    cols.push(col);
+                    line += 1;
+                    col = 0;
+                    first_line = false;
+                    at_line_start = true;
+                    continue;
+                }
+                // Push one (line, col) per byte of `current`.
+                let n_bytes = current.len_utf8();
+                let w = current.len_utf16() as u32;
+                for _ in 0..n_bytes {
+                    lines.push(line);
+                    cols.push(col);
+                }
+                col += w;
+                continue;
+            }
+
+            if ch == '\n' {
+                lines.push(line);
+                cols.push(col);
+                line += 1;
+                col = 0;
+                first_line = false;
+                at_line_start = true;
+                continue;
+            }
+
+            let n_bytes = ch.len_utf8();
+            let w = ch.len_utf16() as u32;
+            for _ in 0..n_bytes {
+                lines.push(line);
+                cols.push(col);
+            }
+            col += w;
+        }
+
+        let _ = first_line;
+        let dedented_len = lines.len() as u32;
+        BlockMap { lines, cols, dedented_len, end_line: line, end_col: col }
+    }
+
+    /// Translate a dedented byte offset to (line, col). Offsets at or past the
+    /// end of content return the position one past the last character.
+    fn pos_at(&self, off: u32) -> (u32, u32) {
+        let n = self.lines.len();
+        if n == 0 { return (self.end_line, self.end_col); }
+        if (off as usize) < n {
+            (self.lines[off as usize], self.cols[off as usize])
+        } else {
+            (self.end_line, self.end_col)
+        }
+    }
+}
+
+/// A located block extracted from the source: its dedented-byte origin and
+/// the map needed to turn dedented offsets back into absolute positions.
+#[allow(dead_code)]
+struct SmBlock {
+    /// Absolute byte offset in `src` of the first content byte (after any
+    /// leading indent has been skipped on line 1). Used only for locating
+    /// adjacent sm comments.
+    content_end_byte: u32,
+    /// Indent level of the block's content lines (for scanning the
+    /// trailing `# sm:` comment on a ƒink block).
+    indent: u32,
+    /// The BlockMap for dedented-byte → (line, col) resolution.
+    map: BlockMap,
+    /// The line number of the block's last content line (used to locate the
+    /// sm comment that should follow).
+    last_content_line: u32,
+    /// The sm payload base64 string, extracted from the trailing comment if
+    /// this is an expectation block. `None` if no payload was found here.
+    sm_payload: Option<String>,
+}
+
+/// Compute dedent strip-level and content-start byte for a ƒink Block's body.
+/// Given the source text and the body's first-item byte range, walk backwards
+/// to the start of that line and find the common leading-whitespace across
+/// subsequent body lines (same rule as the lexer uses for block strings).
+fn compute_fink_block_content(
+    src: &str,
+    first_byte: u32,
+    last_byte: u32,
+) -> Option<(u32, u32, u32, u32, u32)> {
+    // Returns (content_start_byte, content_end_byte, strip, first_line, first_col).
+    let s = src.as_bytes();
+    let first = first_byte as usize;
+    let last = (last_byte as usize).min(s.len());
+    if first >= s.len() { return None; }
+
+    // Walk back to start of the first content line.
+    let mut line_start = first;
+    while line_start > 0 && s[line_start - 1] != b'\n' {
+        line_start -= 1;
+    }
+
+    // The first content char's column = first - line_start (byte col ≈ char col for ASCII indent).
+    let first_col = (first - line_start) as u32;
+    let strip = first_col;
+
+    // Compute absolute (line, col) of line_start: scan from 0.
+    let mut ln = 0u32;
+    for i in 0..line_start {
+        if s[i] == b'\n' { ln += 1; }
+    }
+    let first_line = ln;
+
+    // Content range in source: from `first` (actual content start after indent)
+    // through last content byte on the block's last line. We use `last` as
+    // given (end of last body item in the AST).
+    //
+    // Extend to end of that line, so the block content includes any trailing
+    // whitespace but NOT the following line. Actually stop at `last` — trailing
+    // whitespace on the last line isn't part of anything meaningful here.
+    let content_start_byte = first as u32;
+    let content_end_byte = last as u32;
+
+    Some((content_start_byte, content_end_byte, strip, first_line, first_col))
+}
+
+/// Collect every "block-literal argument" node in the AST (ƒink Block or
+/// StrRawTempl with `":` open) in document order.
+fn collect_sm_candidates(ast: &Ast, id: AstId, out: &mut Vec<AstId>) {
+    let node = ast.nodes.get(id);
+    match &node.kind {
+        NodeKind::Block { name, .. } => {
+            let name_node = ast.nodes.get(*name);
+            if matches!(&name_node.kind, NodeKind::Ident("ƒink")) {
+                out.push(id);
+            }
+            // Don't recurse into ƒink block bodies — nested test DSLs possible but
+            // the sm comment is attached to the outer expectation block.
+            // Still recurse into others.
+            if let NodeKind::Block { body, .. } = &node.kind {
+                for c in body.items.iter() {
+                    collect_sm_candidates(ast, *c, out);
+                }
+            }
+        }
+        NodeKind::StrRawTempl { open, children, .. } => {
+            if open.src == "\":" {
+                out.push(id);
+            }
+            for c in children.iter() {
+                collect_sm_candidates(ast, *c, out);
+            }
+        }
+
+        // Recurse into all container kinds.
+        NodeKind::Module { exprs: children, .. }
+        | NodeKind::LitSeq { items: children, .. }
+        | NodeKind::LitRec { items: children, .. }
+        | NodeKind::Patterns(children) => {
+            for c in children.items.iter() {
+                collect_sm_candidates(ast, *c, out);
+            }
+        }
+        NodeKind::Apply { func, args } => {
+            collect_sm_candidates(ast, *func, out);
+            for a in args.items.iter() {
+                collect_sm_candidates(ast, *a, out);
+            }
+        }
+        NodeKind::Pipe(children) => {
+            for c in children.items.iter() {
+                collect_sm_candidates(ast, *c, out);
+            }
+        }
+        NodeKind::Fn { params, body, .. } => {
+            collect_sm_candidates(ast, *params, out);
+            for e in body.items.iter() {
+                collect_sm_candidates(ast, *e, out);
+            }
+        }
+        NodeKind::InfixOp { lhs, rhs, .. }
+        | NodeKind::Bind { lhs, rhs, .. }
+        | NodeKind::BindRight { lhs, rhs, .. }
+        | NodeKind::Member { lhs, rhs, .. } => {
+            collect_sm_candidates(ast, *lhs, out);
+            collect_sm_candidates(ast, *rhs, out);
+        }
+        NodeKind::UnaryOp { operand, .. } => collect_sm_candidates(ast, *operand, out),
+        NodeKind::Group { inner, .. } | NodeKind::Try(inner) => collect_sm_candidates(ast, *inner, out),
+        NodeKind::Spread { inner: Some(inner), .. } => collect_sm_candidates(ast, *inner, out),
+        NodeKind::StrTempl { children, .. } => {
+            for c in children.iter() {
+                collect_sm_candidates(ast, *c, out);
+            }
+        }
+        NodeKind::Match { subjects, arms, .. } => {
+            for s in subjects.items.iter() {
+                collect_sm_candidates(ast, *s, out);
+            }
+            for a in arms.items.iter() {
+                collect_sm_candidates(ast, *a, out);
+            }
+        }
+        NodeKind::Arm { lhs, body, .. } => {
+            collect_sm_candidates(ast, *lhs, out);
+            for e in body.items.iter() {
+                collect_sm_candidates(ast, *e, out);
+            }
+        }
+        NodeKind::ChainedCmp(parts) => {
+            for part in parts.iter() {
+                if let fink::ast::CmpPart::Operand(op) = part {
+                    collect_sm_candidates(ast, *op, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Build SmBlock data from a single AST candidate node.
+/// `sm_payload` is only set when a trailing sm comment is found in the source.
+fn build_sm_block(src: &str, ast: &Ast, id: AstId) -> Option<SmBlock> {
+    let node = ast.nodes.get(id);
+
+    match &node.kind {
+        NodeKind::Block { body, .. } => {
+            // ƒink: block — use source text of body range for BlockMap.
+            let first_item = body.items.first()?;
+            let last_item = body.items.last()?;
+            let first_node = ast.nodes.get(*first_item);
+            let last_node = ast.nodes.get(*last_item);
+            let first_byte = first_node.loc.start.idx;
+            let last_byte = last_node.loc.end.idx;
+
+            let (cs, ce, strip, first_line, first_col) =
+                compute_fink_block_content(src, first_byte, last_byte)?;
+
+            let block_text = &src[cs as usize .. ce as usize];
+            // first line of block_text starts with zero indent (we already pointed
+            // at the first content char); subsequent lines are full source lines
+            // with `strip` bytes of leading indent we want to strip.
+            let map = BlockMap::build(block_text, first_line, first_col, strip);
+
+            // Determine last_content_line: scan source to find the line of the
+            // last content byte.
+            let mut ln = 0u32;
+            let sbytes = src.as_bytes();
+            for i in 0..(ce as usize).min(sbytes.len()) {
+                if sbytes[i] == b'\n' { ln += 1; }
+            }
+            let last_content_line = ln;
+
+            // Look for a trailing `# sm:<base64>` comment immediately after
+            // this block's content, indented at `strip`.
+            let sm_payload = scan_sm_comment_after(src, ce, strip, "# sm:");
+
+            Some(SmBlock {
+                content_end_byte: ce,
+                indent: strip,
+                map,
+                last_content_line,
+                sm_payload,
+            })
+        }
+        NodeKind::StrRawTempl { children, open, close, .. } if open.src == "\":" => {
+            // wat": block — content is composed of LitStr segments. For our
+            // tests these are always a single LitStr with the full raw body.
+            // We extract the content text from the source between open.end and
+            // close.start (which is the dedent marker).
+            let content_start = open.loc.end.idx;
+            let content_end = close.loc.start.idx;
+            if content_end <= content_start || (content_end as usize) > src.len() {
+                return None;
+            }
+
+            // Use the first LitStr child's indent to determine strip level.
+            let strip = children.iter().find_map(|cid| {
+                if let NodeKind::LitStr { indent, .. } = &ast.nodes.get(*cid).kind {
+                    Some(*indent)
+                } else {
+                    None
+                }
+            }).unwrap_or(0);
+
+            // Walk back from content_start to find line start; compute first_line/first_col.
+            // For `wat":\n   foo`, content_start is right after `":`, which sits
+            // at end of the header line. The first actual content starts on the
+            // next line, after `strip` bytes of indent.
+            let sbytes = src.as_bytes();
+            let mut ln = 0u32;
+            for i in 0..(content_start as usize).min(sbytes.len()) {
+                if sbytes[i] == b'\n' { ln += 1; }
+            }
+            // content_start points at the newline following `":` (or right after it).
+            // Skip leading newline + first-line indent to get to first content char.
+            let mut i = content_start as usize;
+            // Skip the first newline character.
+            if i < sbytes.len() && sbytes[i] == b'\n' { i += 1; ln += 1; }
+            // Skip `strip` spaces.
+            let content_first_byte = i + (strip as usize).min(
+                sbytes[i..(content_end as usize).min(sbytes.len())]
+                    .iter()
+                    .position(|&b| b != b' ')
+                    .unwrap_or(0)
+            );
+
+            let first_col = strip;
+            let first_line = ln;
+
+            // Block text includes from the first content char to content_end.
+            let block_text = &src[content_first_byte .. content_end as usize];
+            // But we want to trim the trailing `;; sm:…` line from block_text
+            // before building the map — the sm comment is inside the raw
+            // content but NOT inside the sourcemap coordinate space.
+            let (text_for_map, sm_payload) = split_trailing_sm_line(block_text, ";; sm:");
+
+            let map = BlockMap::build(text_for_map, first_line, first_col, strip);
+
+            // Compute last_content_line from the trimmed text length.
+            let trimmed_end_byte = content_first_byte + text_for_map.len();
+            let mut lc = 0u32;
+            for i in 0..trimmed_end_byte.min(sbytes.len()) {
+                if sbytes[i] == b'\n' { lc += 1; }
+            }
+
+            Some(SmBlock {
+                content_end_byte: trimmed_end_byte as u32,
+                indent: strip,
+                map,
+                last_content_line: lc,
+                sm_payload,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Scan source for a `<prefix><base64>` comment immediately after `from_byte`,
+/// indented at exactly `indent` spaces. Returns the base64 payload.
+fn scan_sm_comment_after(src: &str, from_byte: u32, indent: u32, prefix: &str) -> Option<String> {
+    let s = src.as_bytes();
+    let mut i = from_byte as usize;
+    // Skip to start of next line.
+    while i < s.len() && s[i] != b'\n' { i += 1; }
+    if i >= s.len() { return None; }
+    i += 1; // past the newline
+
+    // Require `indent` spaces.
+    let line_start = i;
+    let mut spaces = 0u32;
+    while spaces < indent && i < s.len() && s[i] == b' ' {
+        spaces += 1;
+        i += 1;
+    }
+    if spaces < indent { return None; }
+
+    // Check for prefix.
+    let pb = prefix.as_bytes();
+    if i + pb.len() > s.len() { return None; }
+    if &s[i..i + pb.len()] != pb { return None; }
+    i += pb.len();
+
+    // Read base64 payload to end of line.
+    let start = i;
+    while i < s.len() && s[i] != b'\n' { i += 1; }
+    let end = i;
+
+    // Trim trailing whitespace.
+    let mut actual_end = end;
+    while actual_end > start && (s[actual_end - 1] == b' ' || s[actual_end - 1] == b'\t' || s[actual_end - 1] == b'\r') {
+        actual_end -= 1;
+    }
+    let _ = line_start;
+    Some(src[start..actual_end].to_string())
+}
+
+/// Split a raw-string content at its trailing sm comment line.
+/// Returns (text_before_sm_line, Some(payload)) or (full_text, None).
+/// The sm line is `<indent><prefix><base64>` with indent matching the block.
+fn split_trailing_sm_line<'a>(text: &'a str, prefix: &str) -> (&'a str, Option<String>) {
+    // Find last newline; the sm line (if any) is on the final line.
+    // But block content may end with `\n` before dedent — we want the last
+    // non-empty line.
+    let bytes = text.as_bytes();
+    let mut end = bytes.len();
+    // Strip trailing empty lines/whitespace.
+    while end > 0 && (bytes[end - 1] == b'\n' || bytes[end - 1] == b' ' || bytes[end - 1] == b'\r' || bytes[end - 1] == b'\t') {
+        end -= 1;
+    }
+    // Find start of final line.
+    let mut line_start = end;
+    while line_start > 0 && bytes[line_start - 1] != b'\n' {
+        line_start -= 1;
+    }
+    let line = &text[line_start..end];
+    // The sm line may be indented; trim leading whitespace.
+    let trimmed = line.trim_start();
+    if let Some(rest) = trimmed.strip_prefix(prefix) {
+        // Strip trailing whitespace from rest.
+        let payload = rest.trim().to_string();
+        // Return text up to and including the newline before line_start.
+        // `line_start` is the position right after the newline that ended the
+        // previous line, so `line_start - 1` is that newline. We want the
+        // text BEFORE that newline (so the sm line is fully excluded).
+        let chop = if line_start > 0 && bytes[line_start - 1] == b'\n' {
+            line_start - 1
+        } else {
+            line_start
+        };
+        (&text[..chop], Some(payload))
+    } else {
+        (text, None)
+    }
+}
+
+/// Decode a base64url sourcemap payload using fink's SourceMap decoder.
+fn decode_sm(payload: &str) -> Option<SourceMap> {
+    SourceMap::decode_base64url(payload).ok()
+}
+
+/// For each mapping, compute the output span's (start, end) in the dedented
+/// output-block text. The "span" runs from this mapping's `out` until the
+/// next mapping's `out` (or end of output).
+fn output_spans(sm: &SourceMap, output_len: u32) -> Vec<(u32, u32)> {
+    let n = sm.mappings.len();
+    let mut out = Vec::with_capacity(n);
+    for i in 0..n {
+        let start = sm.mappings[i].out;
+        let end = if i + 1 < n { sm.mappings[i + 1].out } else { output_len };
+        out.push((start, end));
+    }
+    out
+}
+
+/// Emit the full JSON payload for TS consumption.
+///
+/// Shape:
+///   [
+///     {
+///       "mappings": [
+///         {
+///           "out":{"line":N,"col":N,"endLine":N,"endCol":N},
+///           "src":{"line":N,"col":N,"endLine":N,"endCol":N}   // may be omitted
+///         },
+///         ...
+///       ]
+///     },
+///     ...
+///   ]
+#[wasm_bindgen]
+pub fn get_sm_mappings(src: &str) -> String {
+    let parsed = match passes::parse(src, "") {
+        Ok(r) => r,
+        Err(_) => return "[]".to_string(),
+    };
+
+    let mut candidates = Vec::new();
+    collect_sm_candidates(&parsed, parsed.root, &mut candidates);
+
+    // Order by document position.
+    candidates.sort_by_key(|id| parsed.nodes.get(*id).loc.start.idx);
+
+    // Build every candidate block up-front so we can find expectation blocks
+    // (those with an sm payload) and pair each with its immediate predecessor
+    // (the input block in the same assertion).
+    let built: Vec<Option<SmBlock>> = candidates
+        .iter()
+        .map(|id| build_sm_block(src, &parsed, *id))
+        .collect();
+
+    let mut groups: Vec<String> = Vec::new();
+    for (i, maybe_expect) in built.iter().enumerate() {
+        let Some(expect_block) = maybe_expect else { continue };
+        let Some(payload) = &expect_block.sm_payload else { continue };
+        if i == 0 { continue };
+        let Some(input_block) = &built[i - 1] else { continue };
+
+        let Some(sm) = decode_sm(payload) else { continue };
+
+        let out_len = expect_block.map.dedented_len;
+        let spans = output_spans(&sm, out_len);
+
+        let mut mapping_strs: Vec<String> = Vec::new();
+        for (idx, m) in sm.mappings.iter().enumerate() {
+            let (out_s, out_e) = spans[idx];
+            let (out_sl, out_sc) = expect_block.map.pos_at(out_s);
+            let (out_el, out_ec) = expect_block.map.pos_at(out_e);
+            let src_json = if let Some(sr) = m.src {
+                let (sl, sc) = input_block.map.pos_at(sr.start);
+                let (el, ec) = input_block.map.pos_at(sr.end);
+                format!(
+                    r#","src":{{"line":{sl},"col":{sc},"endLine":{el},"endCol":{ec}}}"#
+                )
+            } else {
+                String::new()
+            };
+            mapping_strs.push(format!(
+                r#"{{"out":{{"line":{out_sl},"col":{out_sc},"endLine":{out_el},"endCol":{out_ec}}}{src_json}}}"#
+            ));
+        }
+
+        groups.push(format!(r#"{{"mappings":[{}]}}"#, mapping_strs.join(",")));
+    }
+
+    format!("[{}]", groups.join(","))
 }


### PR DESCRIPTION
## Summary

- Hover or click a mapped span inside a fink compiler test expectation → extension lights up the matching input and output spans using the `# sm:` / `;; sm:` payload. Makes reviewing sourcemap correctness visual rather than base64-gazing.
- Bumps embedded fink v0.53.2 → v0.54.0 (new sourcemap payload format).

## Implementation

- New `get_sm_mappings(src)` WASM export: walks the AST for `ƒink:` / `wat\":` block pairs, decodes the sm payload via `fink::sourcemap::native::SourceMap::decode_base64url`, and returns mappings as document-absolute UTF-16 `{line, col, endLine, endCol}` ranges in JSON.
- TS side: hover + selection-change listeners drive two theme-aware 1px bordered decorations — `editorWarning.foreground` (output) and `editorInfo.foreground` (source). Smallest-span lookup picks the innermost mapping containing the cursor.
- Byte → UTF-16 column conversion in `BlockMap` handles `·`, `∅`, `ƒ` (multi-byte UTF-8 but single-unit UTF-16).
- `scripts/smoke-sm.mjs` — dev smoke test; verified across all 22 CPS/WAT test files in ../fink (225 tests, all pass).

## Test plan

- [ ] Open a CPS test file (e.g. `fink/src/passes/cps/test_literals.fnk`), hover/click a mapped position in either the `ƒink:` input block or the `ƒink:` expectation block — both sides get bordered highlight.
- [ ] Open a WAT test file (e.g. `fink/src/passes/wasm/test_literals.fnk`), same behaviour; output-side spans with `src=<none>` highlight only the output side.
- [ ] Non-fink-test files (e.g. the extension's own TS/Rust) — no highlighting, no errors in the extension host log.
- [ ] Edit inside a mapped test — cache invalidates and new mappings apply without reload.