### PR TITLE
fix: clarify extension is for the ƒink programming language

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "license": "MIT",
   "displayName": "fink",
   "icon": "./build/pkg/images/icon.png",
-  "description": "VSCode syntax highlighting for fink.",
+  "description": "Language support for the ƒink programming language (https://github.com/fink-lang).",
   "engines": {
     "vscode": "^1.50.0"
   },


### PR DESCRIPTION
Closes #77.

## Summary

Updates the marketplace `description` in `package.json` to explicitly name the ƒink programming language and link its GitHub org, disambiguating from the [macOS fink package manager](https://fink.sourceforge.net/) as requested in #77.

## Test plan

- [ ] Marketplace listing shows the new description after next release.