### PR TITLE
feat: upgrade fink v0.91.0 -> v0.100.0, package-path import resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
 [[package]]
 name = "fink"
 version = "0.0.0"
-source = "git+https://github.com/fink-lang/fink.git?tag=v0.91.0#6c219b1d6943f87a6e8c75a0b39ca018c7d99f84"
+source = "git+https://github.com/fink-lang/fink.git?tag=v0.100.0#1615156977f0fc50d5fa2daa6ebf2aab978ee25d"
 dependencies = [
  "gimli 0.33.0",
  "wasm-encoder 0.250.0",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
 
 [[package]]
 name = "semver"
@@ -294,12 +294,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -352,25 +352,25 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "252.0.0"
+version = "253.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
 dependencies = [
  "bumpalo",
  "gimli 0.32.3",
  "leb128fmt",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.252.0"
+version = "1.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
 dependencies = [
- "wast 252.0.0",
+ "wast 253.0.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 path = "src/lib.rs"
 
 [dependencies]
-fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.91.0", default-features = false }
+fink = { git = "https://github.com/fink-lang/fink.git", tag = "v0.100.0", default-features = false }
 wasm-bindgen = "0.2"
 
 [profile.release]

--- a/package-lock.json
+++ b/package-lock.json
@@ -218,22 +218,22 @@
       }
     },
     "node_modules/@azure/msal-browser": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.15.0.tgz",
-      "integrity": "sha512-2NYT6v+eeQn8kmNddr9LnbXSvXbVELpmFMmfFvtRxD7I/5+5GlkMlncApeuRFj+mY6C9syOwQip1a0Y+TIbyiA==",
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-browser/-/msal-browser-5.16.0.tgz",
+      "integrity": "sha512-Wc75FGnQgYpsm5jsOqn1H8AXsh8vXruA6vwip1nhjrJxwby7juxKAIVLr7csepmHiwdZGr6EwI5BlSc3PizEtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.10.0"
+        "@azure/msal-common": "16.11.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/msal-common": {
-      "version": "16.10.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.10.0.tgz",
-      "integrity": "sha512-iYtjpanlv6963Jprs0MvzIap07V+QhultjQctfbEDQCflsDAEeO3R7XnVA5gk30fhoBFLdgJT7VqO0TGsEsN9w==",
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-16.11.0.tgz",
+      "integrity": "sha512-UikJOtMwkFpZNzTH6Dqk8UTUPbow15zH3e0UjGYZy69lYENW/S05gMLhbxI2eonz66uALhIljvhsSMEb6+O30g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -241,13 +241,13 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.0.tgz",
-      "integrity": "sha512-fXtJX811pX8y8QlrQqBSH6+plvWyKZDI0IxkheAcyAw9OtcpXyFivmTC7eGUqutLWaDlKXuQ3yOESD4zAmkjHg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-5.3.1.tgz",
+      "integrity": "sha512-sqqv3L1UOI4KDXonNtbxPYUgbSWVXqxvmmb6BUw9n4P/UXgG+cVur3dLWQN4Cz7qQ+UJROCCxMXlksm7gIq0Sw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@azure/msal-common": "16.10.0",
+        "@azure/msal-common": "16.11.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -291,9 +291,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -303,9 +303,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1214,9 +1214,9 @@
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.10",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.10.tgz",
-      "integrity": "sha512-KxNC2pTqqhszMNrf12ZRd4PonRgyJdsM4F/jySiddQK+DsRcfBtUvqn8t7UsyZhnRJHvX46OohDt5N3VqIWC2w==",
+      "version": "10.0.11",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
+      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1522,9 +1522,9 @@
       }
     },
     "node_modules/@semantic-release/github": {
-      "version": "12.0.8",
-      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.8.tgz",
-      "integrity": "sha512-tej5AAgK5X9wHRoDmYhecMXEHEkFeGOY1XsEblKxu8pIQwahzf1STYyr7iPU6Lpbg6C5I3N2w/ocXrBo+L7jhw==",
+      "version": "12.0.9",
+      "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-12.0.9.tgz",
+      "integrity": "sha512-ODIqb0V3QqndipryEEiaBxUQCFjvv7Oese5Dt4omMGa60YRNEW0Sx3K+zri0uac2Y6S9nOlMehciWIzvvRCTGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2512,9 +2512,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3895,9 +3895,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "dev": true,
       "funding": [
         {
@@ -4040,9 +4040,9 @@
       "optional": true
     },
     "node_modules/fs-extra": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
-      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "version": "11.3.6",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
+      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5027,9 +5027,9 @@
       "license": "MIT"
     },
     "node_modules/linkify-it": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
-      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
       "dev": true,
       "funding": [
         {
@@ -5210,9 +5210,9 @@
       }
     },
     "node_modules/markdown-it": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
-      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
       "dev": true,
       "funding": [
         {
@@ -5227,8 +5227,8 @@
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1",
-        "entities": "^4.4.0",
-        "linkify-it": "^5.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
         "mdurl": "^2.0.0",
         "punycode.js": "^2.3.1",
         "uc.micro": "^2.1.0"
@@ -5492,9 +5492,9 @@
       "license": "MIT"
     },
     "node_modules/node-abi": {
-      "version": "3.92.0",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
-      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "version": "3.94.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.94.0.tgz",
+      "integrity": "sha512-W5ZNO5KRPB5TkYmGVD9F6YqhsglXJzE6etpbmT+f6EQElhiX/UTG551cnsRGvLG3fyZEg9HwaDmNmj5nwJ4z9g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -5572,9 +5572,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.17.0",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.17.0.tgz",
-      "integrity": "sha512-PurxiZexEHDTE4SSaLI3ZrnbAGiZfeyUcQcxcP5D+hfytNAze/D1IzDuInTn9XVLIbAQUnQuSPXJx02LHjLvQw==",
+      "version": "11.18.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz",
+      "integrity": "sha512-T67M4L5wNm0cZ7EBLErcEkY1SmzEW/WJ+SADBzsFUY1UdAPfFHXFQtZ6SEXiK0+vzXysCvAsepbMaBTwnrAD+w==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -5653,8 +5653,8 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.8.0",
-        "@npmcli/config": "^10.11.0",
+        "@npmcli/arborist": "^9.9.0",
+        "@npmcli/config": "^10.12.0",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
         "@npmcli/metavuln-calculator": "^9.0.3",
@@ -5678,11 +5678,11 @@
         "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.10",
-        "libnpmexec": "^10.3.0",
-        "libnpmfund": "^7.0.24",
+        "libnpmdiff": "^8.1.11",
+        "libnpmexec": "^10.3.1",
+        "libnpmfund": "^7.0.25",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.10",
+        "libnpmpack": "^9.1.11",
         "libnpmpublish": "^11.2.0",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
@@ -5698,7 +5698,7 @@
         "npm-install-checks": "^8.0.0",
         "npm-package-arg": "^13.0.2",
         "npm-pick-manifest": "^11.0.3",
-        "npm-profile": "^12.0.1",
+        "npm-profile": "^12.0.2",
         "npm-registry-fetch": "^19.1.1",
         "npm-user-validate": "^4.0.0",
         "p-map": "^7.0.4",
@@ -5707,11 +5707,11 @@
         "proc-log": "^6.1.0",
         "qrcode-terminal": "^0.12.0",
         "read": "^5.0.1",
-        "semver": "^7.8.4",
+        "semver": "^7.8.5",
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.16",
+        "tar": "^7.5.19",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -5800,7 +5800,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.8.0",
+      "version": "9.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -5848,7 +5848,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "10.11.0",
+      "version": "10.12.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -6193,7 +6193,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.6",
+      "version": "5.0.7",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -6567,12 +6567,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.10",
+      "version": "8.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -6586,13 +6586,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.3.0",
+      "version": "10.3.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -6609,12 +6609,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.24",
+      "version": "7.0.25",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0"
+        "@npmcli/arborist": "^9.9.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -6634,12 +6634,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.10",
+      "version": "9.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.8.0",
+        "@npmcli/arborist": "^9.9.0",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -7008,13 +7008,13 @@
       }
     },
     "node_modules/npm/node_modules/npm-profile": {
-      "version": "12.0.1",
+      "version": "12.0.2",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "npm-registry-fetch": "^19.0.0",
-        "proc-log": "^6.0.0"
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -7219,7 +7219,7 @@
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
-      "version": "7.8.4",
+      "version": "7.8.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -7344,7 +7344,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.16",
+      "version": "7.5.19",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -7440,7 +7440,7 @@
       }
     },
     "node_modules/npm/node_modules/undici": {
-      "version": "6.26.0",
+      "version": "6.27.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -7705,9 +7705,9 @@
       }
     },
     "node_modules/p-map": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.4.tgz",
-      "integrity": "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
+      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8186,9 +8186,9 @@
       }
     },
     "node_modules/read-package-up/node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -8222,9 +8222,9 @@
       }
     },
     "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.7.0.tgz",
-      "integrity": "sha512-1URUxUqfHFM1c+zfSPsa3gnkO7Aq21qyH75SIduNYz4SzY964rn1X2vCMQaHSHhktiw+0kPa2iyb6PUpXqB6Vg==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.8.0.tgz",
+      "integrity": "sha512-YGYEVz3Fm5iy/AybuA0oyNFq7H4CgQNfRp/qfe8nurE1kuCeNm3/vfm9X4Mtl+qLyaKJUh5xrFZwogr41SMjYA==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "dependencies": {
@@ -9479,9 +9479,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -127,10 +127,13 @@
     "configuration": {
       "title": "fink",
       "properties": {
-        "fink.stdPath": {
-          "type": "string",
-          "default": "",
-          "description": "Path to the fink std/ directory, used to resolve 'std/*' imports for go-to-definition. Absolute, or relative to the workspace folder. Overrides the FINK_STD environment variable. When empty, defaults to <workspace>/std."
+        "fink.packagePaths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": ["pkgs"],
+          "description": "Package search roots for resolving 'std/*', 'fink/*', and other package imports in go-to-definition. Each entry is a directory under which packages live as <root>/<pkg>/<path> (e.g. a checkout of fink's 'pkgs/' directory). Entries are tried in order; the first existing file wins. Each entry is absolute, or relative to the workspace folder. When empty, the FINK_PKGS environment variable (colon-separated) is used instead."
         }
       }
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -137,42 +137,52 @@ interface DiagnosticEntry {
 const diagnosticCollection = vscode.languages.createDiagnosticCollection('fink');
 const semanticTokensChangeEmitter = new vscode.EventEmitter<void>();
 
-// Resolve the directory holding the std/ modules for a given source file.
-// Order: fink.stdPath setting -> FINK_STD env var -> <workspaceRoot>/std.
-// A non-absolute setting value is resolved against the workspace folder.
-function stdRootUri(sourceUri: vscode.Uri): vscode.Uri | undefined {
+// Resolve the package search roots for a given source file.
+// Order: fink.packagePaths setting -> FINK_PKGS env var (colon-separated).
+// A non-absolute entry is resolved against the source file's workspace folder.
+// Packages (std, fink, ...) live under a `pkgs/` root as <root>/<pkg>/<path>.
+function packageRootUris(sourceUri: vscode.Uri): vscode.Uri[] {
   const workspaceFolder = vscode.workspace.getWorkspaceFolder(sourceUri);
 
   const configured = vscode.workspace
     .getConfiguration('fink', sourceUri)
-    .get<string>('stdPath', '')
-    .trim();
-  const envPath = (process.env.FINK_STD ?? '').trim();
-  const setting = configured || envPath;
+    .get<string[]>('packagePaths', []);
+  const envPaths = (process.env.FINK_PKGS ?? '')
+    .split(':')
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
 
-  if (setting) {
-    if (setting.startsWith('/')) return vscode.Uri.file(setting);
-    if (!workspaceFolder) return undefined;
-    return vscode.Uri.joinPath(workspaceFolder.uri, setting);
+  const entries = (configured.length > 0 ? configured : envPaths)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  const roots: vscode.Uri[] = [];
+  for (const entry of entries) {
+    if (entry.startsWith('/')) {
+      roots.push(vscode.Uri.file(entry));
+    } else if (workspaceFolder) {
+      roots.push(vscode.Uri.joinPath(workspaceFolder.uri, entry));
+    }
   }
-
-  if (!workspaceFolder) return undefined;
-  return vscode.Uri.joinPath(workspaceFolder.uri, 'std');
+  return roots;
 }
 
 // Resolve an import URL to a target file URI, or undefined if not resolvable.
-//   ./x, ../x   -> relative to the source file's directory
-//   std/x       -> <stdRoot>/x  (see stdRootUri)
-//   anything else (e.g. @fink/...) -> undefined
-function resolveImportUri(sourceUri: vscode.Uri, url: string): vscode.Uri | undefined {
+//   ./x, ../x     -> relative to the source file's directory
+//   std/x, fink/y -> first <packageRoot>/<url> that exists (see packageRootUris)
+async function resolveImportUri(sourceUri: vscode.Uri, url: string): Promise<vscode.Uri | undefined> {
   if (url.startsWith('./') || url.startsWith('../')) {
     const sourceDir = vscode.Uri.joinPath(sourceUri, '..');
     return vscode.Uri.joinPath(sourceDir, url);
   }
-  if (url.startsWith('std/')) {
-    const stdRoot = stdRootUri(sourceUri);
-    if (!stdRoot) return undefined;
-    return vscode.Uri.joinPath(stdRoot, url.slice('std/'.length));
+  for (const root of packageRootUris(sourceUri)) {
+    const candidate = vscode.Uri.joinPath(root, url);
+    try {
+      await vscode.workspace.fs.stat(candidate);
+      return candidate;
+    } catch {
+      // Not in this root — try the next.
+    }
   }
   return undefined;
 }
@@ -185,7 +195,7 @@ async function resolveImportDefinition(
 ): Promise<vscode.Location | undefined> {
   if (!ParsedDocument) return undefined;
 
-  const targetUri = resolveImportUri(sourceUri, url);
+  const targetUri = await resolveImportUri(sourceUri, url);
   if (!targetUri) return undefined;
 
   try {
@@ -221,7 +231,7 @@ function findImportAt(doc: ParsedDocumentHandle, line: number, col: number): { u
 }
 
 // Check if the cursor is on an import URL string, return the resolved file URI if so.
-function findImportUrlAt(doc: ParsedDocumentHandle, documentUri: vscode.Uri, line: number, col: number): vscode.Uri | undefined {
+async function findImportUrlAt(doc: ParsedDocumentHandle, documentUri: vscode.Uri, line: number, col: number): Promise<vscode.Uri | undefined> {
   const imports: ImportEntry[] = JSON.parse(doc.get_imports());
   for (const imp of imports) {
     if (imp.urlLine === line && imp.urlCol <= col && col < imp.urlEndCol) {
@@ -257,7 +267,7 @@ const definitionProvider: vscode.DefinitionProvider = {
     if (!doc) return undefined;
 
     // Cmd+click on import URL string → open the file
-    const importFileUri = findImportUrlAt(doc, document.uri, position.line, position.character);
+    const importFileUri = await findImportUrlAt(doc, document.uri, position.line, position.character);
     if (importFileUri) {
       return new vscode.Location(importFileUri, new vscode.Position(0, 0));
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,26 +120,27 @@ fn collect_tokens<'src>(ast: &'src Ast<'src>, id: AstId, tokens: &mut Vec<RawTok
         NodeKind::LitRec { items: children, .. } => {
             for child_id in children.items.iter() {
                 let child = ast.nodes.get(*child_id);
-                if let NodeKind::Arm { lhs, body, .. } = &child.kind {
-                    let lhs_node = ast.nodes.get(*lhs);
-                    if let NodeKind::Patterns(pats) = &lhs_node.kind {
-                        if let Some(first_lhs_id) = pats.items.first() {
-                            let first_lhs = ast.nodes.get(*first_lhs_id);
-                            if matches!(&first_lhs.kind, NodeKind::Ident(_)) {
-                                if body.items.is_empty() {
-                                    emit_token(tokens, first_lhs, TOKEN_VARIABLE, MOD_READONLY);
-                                } else {
-                                    emit_token(tokens, first_lhs, TOKEN_PROPERTY, 0);
-                                }
-                            }
+                match &child.kind {
+                    // Field with a value (`{foo: 1}` / `{foo = 1}`): emit a
+                    // property token on the ident key, then recurse the value.
+                    NodeKind::NamedValue { name, value, .. } => {
+                        let name_node = ast.nodes.get(*name);
+                        if matches!(&name_node.kind, NodeKind::Ident(_)) {
+                            emit_token(tokens, name_node, TOKEN_PROPERTY, 0);
                         }
+                        collect_tokens(ast, *value, tokens);
                     }
-                    // Recurse into arm body
-                    for expr_id in body.items.iter() {
-                        collect_tokens(ast, *expr_id, tokens);
+                    // Non-ident key (`{'bar': 2}` / `{(k): 3}`): no property
+                    // token; recurse both key and value.
+                    NodeKind::KeyValue { key, value, .. } => {
+                        collect_tokens(ast, *key, tokens);
+                        collect_tokens(ast, *value, tokens);
                     }
-                } else {
-                    collect_tokens(ast, *child_id, tokens);
+                    // Shorthand field (`{foo, bar}`): bare ident, read-only.
+                    NodeKind::Ident(_) => {
+                        emit_token(tokens, child, TOKEN_VARIABLE, MOD_READONLY);
+                    }
+                    _ => collect_tokens(ast, *child_id, tokens),
                 }
             }
         }
@@ -171,6 +172,18 @@ fn collect_tokens<'src>(ast: &'src Ast<'src>, id: AstId, tokens: &mut Vec<RawTok
         | NodeKind::Member { lhs, rhs, .. } => {
             collect_tokens(ast, *lhs, tokens);
             collect_tokens(ast, *rhs, tokens);
+        }
+
+        // NamedValue / KeyValue reached outside a record literal (e.g. named
+        // call arguments `foo bar=1`). Recurse into both sides; the record-
+        // specific property-token handling lives in the LitRec arm above.
+        NodeKind::NamedValue { name, value, .. } => {
+            collect_tokens(ast, *name, tokens);
+            collect_tokens(ast, *value, tokens);
+        }
+        NodeKind::KeyValue { key, value, .. } => {
+            collect_tokens(ast, *key, tokens);
+            collect_tokens(ast, *value, tokens);
         }
 
         NodeKind::UnaryOp { operand, .. } => {
@@ -1011,6 +1024,14 @@ fn collect_sm_candidates(ast: &Ast, id: AstId, out: &mut Vec<AstId>) {
         | NodeKind::Member { lhs, rhs, .. } => {
             collect_sm_candidates(ast, *lhs, out);
             collect_sm_candidates(ast, *rhs, out);
+        }
+        NodeKind::NamedValue { name, value, .. } => {
+            collect_sm_candidates(ast, *name, out);
+            collect_sm_candidates(ast, *value, out);
+        }
+        NodeKind::KeyValue { key, value, .. } => {
+            collect_sm_candidates(ast, *key, out);
+            collect_sm_candidates(ast, *value, out);
         }
         NodeKind::UnaryOp { operand, .. } => collect_sm_candidates(ast, *operand, out),
         NodeKind::Group { inner, .. } | NodeKind::Try(inner) => collect_sm_candidates(ast, *inner, out),


### PR DESCRIPTION
## Summary

Upgrades the embedded fink compiler v0.91.0 -> v0.100.0 and reworks package import resolution to match fink's new `pkgs/` layout.

## fink v0.100.0 changes handled

- **AST**: record field-usage `Arm` nodes are split into new `NamedValue` (ident key) and `KeyValue` (string/computed key) `NodeKind` variants. Updated the semantic-token and sourcemap AST walks in `src/lib.rs` to handle both:
  - `{foo: 1}` / `{foo = 1}` -> property token on the ident key
  - `{'bar': 2}` / `{(k): 3}` -> no property token
  - `{foo, bar}` shorthand -> read-only variable (unchanged)
- **Package layout**: std and fink packages now live under a single `pkgs/` root (`pkgs/std/*`, `pkgs/fink/*`).

## Package-path import resolution

Replaces `fink.stdPath` / `FINK_STD` (a single std root, std-only) with:

- **`fink.packagePaths`** (`string[]`, default `["pkgs"]`): a list of package search roots. Any bare `pkg/path` import (`std/x`, `fink/y`, ...) is resolved as `<root>/<url>`, trying each root in order; first existing file wins. Absolute entries used as-is; relative entries resolve against the workspace folder.
- **`FINK_PKGS`** env var (colon-separated) as fallback when the setting is empty.

Point `fink.packagePaths` at a checkout of fink's `pkgs/` directory so cmd-click / F12 on `std/*` and `fink/*` imports (and names imported from them) jumps into the package source.

## Verification

- Clean `make clean && make build` against v0.100.0.
- Runtime check via WASM harness: record field property tokens, import extraction, unresolved/unused diagnostics, and cross-module go-to-definition all correct.
- Resolution logic verified against the real v0.100.0 `pkgs/` layout.